### PR TITLE
fix log level, add tests

### DIFF
--- a/lib/logcast/broadcaster.rb
+++ b/lib/logcast/broadcaster.rb
@@ -8,6 +8,11 @@ class Logcast::Broadcaster
       subscriber.instance_variable_set(:@logcast_original_subscriber, original_subscriber)
     end
 
+    # Apply existing level to the new subscriber.
+    if(subscribers.any?)
+      subscriber.level = subscribers.first.level
+    end
+
     if block
       if already_subscribed?(subscriber)
         yield
@@ -33,12 +38,15 @@ class Logcast::Broadcaster
 
     subscribers.each do |subscriber|
       if subscriber.respond_to?(name)
-        responded = true
-        subscriber.send(name, *args, &block)
+        responded = subscriber.send(name, *args, &block)
       end
     end
 
-    super unless responded
+    if !responded
+      super
+    else
+      responded
+    end
   end
 
   private

--- a/test/logcast/broadcaster_test.rb
+++ b/test/logcast/broadcaster_test.rb
@@ -2,87 +2,133 @@ require File.expand_path('../../test_helper', __FILE__)
 
 describe Logcast::Broadcaster do
   let(:broadcaster){ Logcast::Broadcaster.new }
-  let(:stub){ StringIO.new }
+  let(:stub1){ StringIO.new }
+  let(:stub2){ StringIO.new }
+  let(:logger){ Logger.new(StringIO.new) }
+  let(:logger2){ Logger.new(StringIO.new) }
 
   describe "#silence" do
-    let(:stub) { Logger.new(StringIO.new) }
-
     before do
-      def stub.silence; @called = true; end
+      def logger.silence; @called = true; end
 
-      broadcaster.subscribe(stub)
+      broadcaster.subscribe(logger)
     end
 
     it "passes silence through" do
       broadcaster.silence
-      assert_equal true, stub.instance_variable_get(:@called)
+      assert_equal true, logger.instance_variable_get(:@called)
     end
   end
 
   describe "#subscribe" do
     it "subscribes" do
-      broadcaster.subscribe(stub)
-      assert_equal [stub], subscribers(broadcaster)
+      broadcaster.subscribe(stub1)
+      assert_equal [stub1], subscribers(broadcaster)
     end
 
     it "does not subscribe the same listener twice" do
-      broadcaster.subscribe(stub)
-      broadcaster.subscribe(stub)
+      broadcaster.subscribe(stub1)
+      broadcaster.subscribe(stub1)
 
-      assert_equal [stub], subscribers(broadcaster)
+      assert_equal [stub1], subscribers(broadcaster)
     end
 
     it "can subscribe with a block" do
-      broadcaster.subscribe(stub) do
-        assert_equal [stub], subscribers(broadcaster)
+      broadcaster.subscribe(stub1) do
+        assert_equal [stub1], subscribers(broadcaster)
       end
       assert_equal [], subscribers(broadcaster)
     end
 
     it "unsubscribe with a block on exception" do
       assert_raises ArgumentError do
-        broadcaster.subscribe(stub) do
+        broadcaster.subscribe(stub1) do
           raise ArgumentError.new
         end
       end
       assert_equal [], subscribers(broadcaster)
     end
 
-    it "exeutes a block if the subscriber is already subscribed" do
-      broadcaster.subscribe(stub)
+    it "executes a block if the subscriber is already subscribed" do
+      broadcaster.subscribe(stub1)
       x = 2
-      broadcaster.subscribe(stub) do
+      broadcaster.subscribe(stub1) do
         x = 1
       end
       assert_equal 1, x
     end
 
     it "can subscribe with multiple blocks" do
-      stub2 = StringIO.new
-      broadcaster.subscribe(stub) do
+      broadcaster.subscribe(stub1) do
         broadcaster.subscribe(stub2) do
-          assert_equal [stub, stub2], subscribers(broadcaster)
+          assert_equal [stub1, stub2], subscribers(broadcaster)
         end
-        assert_equal [stub], subscribers(broadcaster)
+        assert_equal [stub1], subscribers(broadcaster)
       end
       assert_equal [], subscribers(broadcaster)
     end
 
     it "raises NoMethodError if nothing responds" do
-      broadcaster.subscribe(stub)
+      broadcaster.subscribe(stub1)
       lambda { broadcaster.notch }.must_raise(NoMethodError)
     end
 
     it "doesn't raise NoMethodError if something responds" do
-      broadcaster.subscribe(stub)
+      broadcaster.subscribe(stub1)
       broadcaster.add(0, 'hi')
+    end
+
+    it "returns level correctly" do
+      logger.level = Logger::DEBUG
+      broadcaster.subscribe(logger)
+
+      assert_equal broadcaster.level, logger.level
+      assert_equal broadcaster.level, Logger::DEBUG
+    end
+
+    it "sets the same level on all subscribers" do
+
+      logger.level = Logger::DEBUG
+      logger2.level = Logger::INFO
+      broadcaster.subscribe(logger)
+
+
+      broadcaster.subscribe(logger2)
+      assert_equal logger.level, logger2.level
+      assert_equal logger.level, Logger::DEBUG
+    end
+
+    it "sets same levels on all subscribers" do
+      logger.level = Logger::INFO
+      logger2.level = Logger::INFO
+
+      broadcaster.subscribe(logger)
+      broadcaster.subscribe(logger2)
+
+      broadcaster.level = Logger::DEBUG
+
+      assert_equal logger.level, Logger::DEBUG
+      assert_equal logger.level, Logger::DEBUG
+    end
+
+    it "sets level correctly on non-loggers" do
+      logger.level = Logger::WARN
+
+      broadcaster.subscribe(logger)
+      broadcaster.subscribe(stub1)
+
+      broadcaster.debug("hello")
+      broadcaster.warn("warning you!")
+
+      stub1.string.wont_include "hello"
+      stub1.string.must_include "warning you!"
     end
   end
 
   [:stringio, :logger, :buffered_logger].each do |type|
     describe "logging to #{type}" do
       let(:recorder) { StringIO.new }
-      let(:logger) do
+      let(:stub_logger) do
         case type
         when :stringio then recorder
         when :logger then Logger.new(recorder)
@@ -92,7 +138,7 @@ describe Logcast::Broadcaster do
       end
 
       it "logs via add" do
-        broadcaster.subscribe(logger)
+        broadcaster.subscribe(stub_logger)
         broadcaster.add(1, "hello")
 
         recorder.string.must_include "hello"


### PR DESCRIPTION
1. Capture the last response and send it back on method_missing (open to better suggestions)
2. Correctly set levels on all subscribers. (All are always on the same level.)

@grosser @steved555 

cc:
@osheroff  @dadah89 
