### PR TITLE
dont call super if reponded with nil response

### DIFF
--- a/lib/logcast/broadcaster.rb
+++ b/lib/logcast/broadcaster.rb
@@ -34,17 +34,12 @@ class Logcast::Broadcaster
   end
 
   def method_missing(name, *args, &block)
-    responded = false
-    response  = nil
-
-    subscribers.each do |subscriber|
-      if subscriber.respond_to?(name)
-        responded = true
-        response = subscriber.send(name, *args, &block)
-      end
+    responding = subscribers.select { |s| s.respond_to?(name) }
+    if responding.any?
+      responding.map { |s| s.send(name, *args, &block) }.last
+    else
+      super
     end
-
-    (responded)? response : super
   end
 
   private


### PR DESCRIPTION
@grosser @steved555 

"silence" returns nil. It was also bad to assume all methods will return non-nil.

Adding no tests, since silence is going away, and I can't find any other method which returns nil on a logger.
