### PR TITLE
Adds respond_to? handler for subscribers

### DIFF
--- a/lib/logcast/broadcaster.rb
+++ b/lib/logcast/broadcaster.rb
@@ -42,6 +42,10 @@ class Logcast::Broadcaster
     end
   end
 
+  def respond_to?(*args)
+    subscribers.any?{|s| s.respond_to?(*args) } || super
+  end
+
   private
 
   def already_subscribed?(logger)

--- a/test/logcast/broadcaster_test.rb
+++ b/test/logcast/broadcaster_test.rb
@@ -78,6 +78,16 @@ describe Logcast::Broadcaster do
       broadcaster.add(0, 'hi')
     end
 
+    it "respond_to? returns false if nothing responds" do
+      broadcaster.subscribe(stub1)
+      refute broadcaster.respond_to?(:foo)
+    end
+
+    it "respond_to? returns true if something responds" do
+      broadcaster.subscribe(stub1)
+      assert broadcaster.respond_to?(:level)
+    end
+
     it "returns level correctly" do
       logger.level = Logger::DEBUG
       broadcaster.subscribe(logger)


### PR DESCRIPTION
@vanchi-zendesk @grosser @steved555 - doing this so that [this](https://github.com/rails/rails/blob/3-2-stable/railties/lib/rails/rack/logger.rb#L15) will return true so that we can maybe eventually tag production logs with a short request uuid for better collation.
