### PR TITLE
Revert "Merge pull request #7 from zendesk/jcheatham/add_respond_to_d…

### DIFF
--- a/lib/logcast/broadcaster.rb
+++ b/lib/logcast/broadcaster.rb
@@ -47,10 +47,6 @@ class Logcast::Broadcaster
     method_missing("warn", *args, &block)
   end
 
-  def respond_to?(*args)
-    subscribers.any?{|s| s.respond_to?(*args) } || super
-  end
-
   private
 
   def already_subscribed?(logger)

--- a/test/logcast/broadcaster_test.rb
+++ b/test/logcast/broadcaster_test.rb
@@ -78,16 +78,6 @@ describe Logcast::Broadcaster do
       broadcaster.add(0, 'hi')
     end
 
-    it "respond_to? returns false if nothing responds" do
-      broadcaster.subscribe(stub1)
-      refute broadcaster.respond_to?(:foo)
-    end
-
-    it "respond_to? returns true if something responds" do
-      broadcaster.subscribe(stub1)
-      assert broadcaster.respond_to?(:level)
-    end
-
     it "returns level correctly" do
       logger.level = Logger::DEBUG
       broadcaster.subscribe(logger)


### PR DESCRIPTION
…elegate"

This reverts commit 038560c9b3543bae1d44266154ab87bbe6894bba, reversing
changes made to 5db2cb40bc34435bfce6af067d3828191b36649d.

One of our loggers allows you include extra attributes to be logged like so:
```
klass.resque_error(exception.to_s, :backtrace => exception.backtrace)
```
`append_attributes` is the method that implements this. We were checking you could actually call the above with `klass.logger.respond_to?(:append_attributes)` which returned `true`. But that then caused the following when not all subscribers accepted multiple arguments:
```
(byebug) e
#<ArgumentError: wrong number of arguments (given 2, expected 0..1)>
(byebug) e.backtrace
["/usr/local/lib/ruby/2.4.0/logger.rb:542:in `error'", "/app/vendor/cache/logcast/lib/logcast/broadcaster.rb:39:in `block in method_missing'",
```

Maybe using `subscribers.all?` would work or I could do some kind of other fix, but since this change was never actually released/used, I figured a revert was simpler and quicker.

@zendesk/sustaining @grosser @jcheatham (👋)