### PR TITLE
Add #respond_to_missing?

### DIFF
--- a/lib/logcast/broadcaster.rb
+++ b/lib/logcast/broadcaster.rb
@@ -42,6 +42,10 @@ class Logcast::Broadcaster
     end
   end
 
+  def respond_to_missing?(name, include_private = false)
+    subscribers.all? { |s| s.respond_to?(name, include_private) } || super
+  end
+
   # Kernel#warn is defined by Ruby
   def warn(*args, &block)
     method_missing("warn", *args, &block)

--- a/test/logcast_test.rb
+++ b/test/logcast_test.rb
@@ -29,6 +29,9 @@ describe Logcast do
       Rails.logger.subscribe(io2)
       Rails.logger.info("foo")
 
+      assert(Rails.logger.respond_to?(:info))
+      refute(Rails.logger.respond_to?(:fake_method))
+
       Fake.io.string.must_include "foo"
       io2.string.must_include "foo"
     end


### PR DESCRIPTION
1. Add `#respond_to_missing?` so that checks like `Rails.logger.respond_to?(:info)` return truthy

I used TDD to test the behavior:

`assert(Rails.logger.respond_to?(:info))`

Before the change, this was false. After the change, it was true.